### PR TITLE
Added support for top-down / bottom-up shades

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use this when you know the local static IP address.
 
 * `"visibleBlindNames"` Comma-seperated list of blind names (prefixed with room name) to make visible. All other blinds are ignored. Only used when `createDiscreteBlinds` is true.
 
-* `"topDownBottomUpBehavior"` Choose the desired behavior for Top-Down / Bottom-Up shades.  If `"topDown"` is specified, the slider will control the middle rail, and the shade will open downward.  If `"bottomUp"` is specified, the slider will control the bottom rail, and the shade will open upward.  Default is `"topDown"`.
+* `"topDownBottomUpBehavior"` Choose the desired behavior for Top-Down / Bottom-Up blinds.  If `"topDown"` is specified, the slider will control the middle rail, and the blind will open downward.  If `"bottomUp"` is specified, the slider will control the bottom rail, and the blind will open upward.  Default is `"topDown"`.  This setting has no effect on standard blinds (i.e., blinds with only "Bottom-Up" functionality).
 
 # Implemented HomeKit Accessory Types
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Use this when you know the local static IP address.
 
 * `"visibleBlindNames"` Comma-seperated list of blind names (prefixed with room name) to make visible. All other blinds are ignored. Only used when `createDiscreteBlinds` is true.
 
+* `"topDownBottomUpBehavior"` Choose the desired behavior for Top-Down / Bottom-Up shades.  If `"topDown"` is specified, the slider will control the middle rail, and the shade will open downward.  If `"bottomUp"` is specified, the slider will control the bottom rail, and the shade will open upward.  Default is `"topDown"`.
+
 # Implemented HomeKit Accessory Types
 
 ## WindowCovering

--- a/config.schema.json
+++ b/config.schema.json
@@ -69,6 +69,15 @@
         "placeholder": "visible blind names",
         "required": false,
         "description": "Optional. Comma-seperated list of blind names (prefixed with room name) to make visible. All other blinds are ignored. Used only if 'Create Discrete Blinds' is true."
+      },"topDownBottomUpBehavior": {
+        "title": "Top-Down / Bottom-Up Behavior",
+        "type": "string",
+        "oneOf": [
+          { "title": "Top-Down", "enum": ["topDown"] },
+          { "title": "Bottom-Up", "enum": ["bottomUp"] }
+        ],
+        "required": false,
+        "description": "Optional. Choose the desired behavior for Top-Down / Bottom-Up shades.  If 'Top-Down' is specified, the slider will control the middle rail, and the shade will open downward.  If 'Bottom-Up' is specified, the slider will control the bottom rail, and the shade will open upward.  Default is 'Top-Down.'"
       }
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,12 +72,13 @@
       },"topDownBottomUpBehavior": {
         "title": "Top-Down / Bottom-Up Behavior",
         "type": "string",
+        "default": "topDown",
         "oneOf": [
           { "title": "Top-Down", "enum": ["topDown"] },
           { "title": "Bottom-Up", "enum": ["bottomUp"] }
         ],
-        "required": false,
-        "description": "Optional. Choose the desired behavior for Top-Down / Bottom-Up shades.  If 'Top-Down' is specified, the slider will control the middle rail, and the shade will open downward.  If 'Bottom-Up' is specified, the slider will control the bottom rail, and the shade will open upward.  Default is 'Top-Down.'"
+        "required": true,
+        "description": "Choose the desired behavior for Top-Down / Bottom-Up shades.  If 'Top-Down' is specified, the slider will control the middle rail, and the shade will open downward.  If 'Bottom-Up' is specified, the slider will control the bottom rail, and the shade will open upward.  Default is 'Top-Down.'"
       }
     }
   }

--- a/lib/BlindAccessory.js
+++ b/lib/BlindAccessory.js
@@ -19,17 +19,39 @@ class BlindAccessory {
    * @param {string} name
    * @param {string} blindId
    * @param {string} roomId
+   * @param {string} shadeTypeId
    * @param {HunterDouglasPlatinumPlatform} platform
    * @memberof BlindAccessory
    */
-  constructor(name, blindId, roomId, platform) {
+  constructor(name, blindId, roomId, shadeTypeId, platform) {
     // name and uuid_base required by homebridge
     this.name = name
     this.blindId = blindId
     this.roomId = roomId
     this.uuid_base = uuid.generate(platform.device_id + ':' + roomId + ':' + blindId)
+    this.shadeTypeId = shadeTypeId
     this.platform = platform
     this.log = platform.log
+
+    // Default feature is bottom-up - Feature ID: "04"
+    this.shadeFeatureId = "04"
+    
+    // Special handling for top-down-bottom-up shades, which can be detected from the room's shadeTypeId
+    
+    // For top-down-bottom-up shades (shadeTypeId 02 or 13), use the top-down feature - Feature ID: "18"
+    if (this.shadeTypeId == "02" || this.shadeTypeId == "13") {
+      if (platform.config.topDownBottomUpBehavior == "topDown") {
+        this.shadeFeatureId = "18"
+      }
+    }
+    
+    platform.log.debug(
+      'BA.constructor for blind named:', this.name, 
+      '- blindId:', this.blindId,
+      '- roomId:', this.roomId,
+      '- shadeTypeId:', this.shadeTypeId,
+      '- shadeFeatureId:', this.shadeFeatureId
+    )
 
     this.windowCoveringService = new Service.WindowCovering(this.name)
 
@@ -56,7 +78,7 @@ class BlindAccessory {
     )
 
     if (shouldSetBlind) {
-      platform.setTargetPosition(this.blindId, newValue)
+      platform.setTargetPosition(this.blindId, this.shadeFeatureId, newValue)
       platform.log.debug('BA._setTargetPosition(updated):', this.name, newValue)
       callback(null)
     } else {

--- a/lib/Bridge.js
+++ b/lib/Bridge.js
@@ -67,7 +67,7 @@ class Controller {
    * set the specified shades (which should be an array of shadeIds) to the position (0-255).
    * returns `()` on success
    */
-  async setPosition(shadeIds, position) {
+  async setPosition(shadeIds, shadeFeatureId, position) {
     return new Promise((resolve, reject) => {
       const connection = new Connection(this.config.port, this.config.ip_address, this.log)
       connection
@@ -76,7 +76,7 @@ class Controller {
           reject(err)
         })
         .on('connected', () => {
-          connection.setPosition(shadeIds, position)
+          connection.setPosition(shadeIds, shadeFeatureId, position)
         })
         .on('set_position', () => {
           connection.close()
@@ -92,8 +92,8 @@ const EXPECTED_HELLO = 'HunterDouglas Shade Controller'
 const CMD_GET_DATA = '$dat'
 const CMD_GET_DATA_TERM = /^\$upd01-$/
 
-function CMD_POS_SET(shadeId, position) {
-  return '$pss' + String(shadeId).padStart(2, '0') + '-04-' + String(position).padStart(3, '0')
+function CMD_POS_SET(shadeId, shadeFeatureId, position) {
+  return '$pss' + String(shadeId).padStart(2, '0') + '-' + String(shadeFeatureId).padStart(2, '0') + '-' + String(position).padStart(3, '0')
 }
 
 const CMD_POS_SET_TERM = /^\$done$/
@@ -164,8 +164,8 @@ class Connection extends EventEmitter {
   }
 
   /** starts things in motion to eventually emit a `set_position` event on success */
-  setPosition(shadeIds, position) {
-    this._setPosition(shadeIds, position)
+  setPosition(shadeIds, shadeFeatureId, position) {
+    this._setPosition(shadeIds, shadeFeatureId, position)
       .then(() => {
         this.emit('set_position')
       })
@@ -179,10 +179,10 @@ class Connection extends EventEmitter {
    * @param {number} position
    * @memberof Connection
    */
-  async _setPosition(shadeIds, position) {
+  async _setPosition(shadeIds, shadeFeatureId, position) {
     for (var shadeId of shadeIds) {
       this.log.debug(`Connection._setPosition: ${shadeId} to ${position}`)
-      await this._command(CMD_POS_SET(shadeId, position), CMD_POS_SET_TERM)
+      await this._command(CMD_POS_SET(shadeId, shadeFeatureId, position), CMD_POS_SET_TERM)
     }
     await this._command(CMD_SET, CMD_SET_TERM)
   }
@@ -307,7 +307,7 @@ class BridgeError extends Error {}
 const FIRM_RE = /^\$firm\d+-(.*)$/
 const MAC_RE = /^\$MAC0x(.*)-$/
 const LED_RE = /^\$LEDl(\d\d\d)-$/
-const ROOM_RE = /^\$cr(\d\d)-[^-]+-[^-]+-(.*)$/
+const ROOM_RE = /^\$cr(\d\d)-(\d\d)-[^-]+-(.*)$/
 const SHADE_RE = /^\$cs(\d\d)-(\d\d)-[^-]+-(.*)$/
 const SHADE_POS_RE = /^\$cp(\d\d)-\d\d-(\d\d\d)-$/
 
@@ -330,8 +330,9 @@ class Config {
         this.homeName = match[1]
       } else if ((match = ROOM_RE.exec(line))) {
         const id = String(match[1]).padStart(2, '0')
-        const name = match[2]
-        this.rooms.set(id, { id: id, name: name, shadeIds: [] })
+        const shadeTypeId = String(match[2]).padStart(2, '0')
+        const name = match[3]
+        this.rooms.set(id, { id: id, shadeTypeId: shadeTypeId, name: name, shadeIds: [] })
       } else if ((match = SHADE_RE.exec(line))) {
         const id = String(match[1]).padStart(2, '0')
         const roomId = String(match[2]).padStart(2, '0')


### PR DESCRIPTION
This plugin is awesome - thank you for your work on it!

I added some basic support for Top-Down / Bottom-Up shades (i.e., shades that can open either up or down).  The current plugin works with these shades, but they always open "bottom-up" (like a standard shade).  People generally get Top-Down / Bottom-Up shades for privacy, so they will normally want the shades down from the top.  These changes provide a config setting to specify whether Top-Down / Bottom-Up shades should open top-down or bottom-up.

The current plugin was hard-coded to control the "bottom-up" functionality by specifying feature "04" in the CMD_POS_SET method of Bridge.js.  The "top-down" functionality is controlled by specifying "18" instead of "04."  For example, "$pss00-04-128" will open shade 00 to 50% by moving the lower rail up, and "$pss00-18-128" will open that same shade to 50% by instead moving the upper rail down.  I added a parameter to CMD_POS_SET (and the functions that call it) to specify which shade feature to control (i.e., "04" or "18").

I also added some some simple code to check whether or not a shade has top-down / bottom-up capabilities.  The shade type is specified in the "$cr" output from the Platinum Hub.  My "Duette Honeycomb" top-down / bottom-up shades are reported as shade-type "02."  My understanding is that shade type "13" corresponds to "Vignette Roman Shades" with top-down / bottom-up functionality.  The code records the shadeTypeId from the $cr output and stores it with the rest of the room info.  It also stores the shadeTypeId in the BlindAccessory, which uses it to decide whether to use feature "04" or "18" to control the shades.

For normal shades, it should only ever use feature "04" (bottom-up).  For top-down / bottom-up shades (i.e., shades with shadeTypeId "02" or "13"), it will decide whether to use feature "04" (bottom-up) or "18" (top-down) based on the "topDownBottomUpBehavior" setting from config.json.

I've tested this on my top-down / bottom-up shades, and it works great.  These changes should not affect the behavior of standard shades (i.e., bottom-up only), but I don't have any standard shades to test.

I hope this is helpful.  Let me know if you have any questions.

